### PR TITLE
Add a conda recipe for pbtest, showing how to require the VC++ runtime

### DIFF
--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -1,0 +1,5 @@
+call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" x64
+set DISTUTILS_USE_SDK=1
+set MSSdk=1
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+${PYTHON} setup.py install;
+

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,29 @@
+package:
+  name: pbtest
+  version: {{ environ.get('GIT_DESCRIBE_TAG', '') }}
+
+build:
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  {% if environ.get('GIT_DESCRIBE_NUMBER', '0') == '0' %}string: py{{ environ.get('PY_VER').replace('.', '') }}_0
+  {% else %}string: py{{ environ.get('PY_VER').replace('.', '') }}_{{ environ.get('GIT_BUILD_STR', 'GIT_STUB') }}{% endif %}
+
+source:
+  git_url: ../
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pybind11
+
+  run:
+    - python
+    - vs2015_runtime  # [win]
+
+test:
+  imports:
+    - pbtest
+
+about:
+  summary: An example project built with pybind11.
+  license_file: LICENSE


### PR DESCRIPTION
This conda recipe includes
 - forcing the use of MSVC 14 as part of the windows build script.
 - requiring the VC++ 14 runtime as a windows-only conda dependency.