### PR TITLE
query pip for pybind11 include path (fixes compilation for Brew-ed Python on OSX)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,18 @@
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
-import os, sys
+from pip import locations
+import os
+import sys
+import setuptools
 
 ext_modules = [
     Extension(
         'pbtest',
         ['py/main.cpp'],
-        include_dirs=['include'],
+        include_dirs=[
+            # Path to pybind11 headers
+            os.path.dirname(locations.distutils_scheme('pybind11')['headers'])
+        ],
         language='c++',
     ),
 ]


### PR DESCRIPTION
The ``setup.py`` script does not currently work on OSX when a Brewed Python is used. It searches for the pybind11 includes in ``/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/include/python3.5m``, but  pip actually installs them in ``/usr/local/include/python3.5m``. I changed the ``setup.py`` script so that pip is queried for the actual path to use.